### PR TITLE
fix list structures + add webhook-messages list

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import type {
   WebhookMessageTarget,
   ApiErrorResponse,
   ApiSuccessResponse,
+  WebhookMessageAttempt,
 } from "./types/index";
 import crypto from "crypto";
 import axios, { AxiosInstance } from "axios";
@@ -82,8 +83,8 @@ class AppAPI {
     return res;
   }
 
-  async list(projectId: string): Promise<ApiSuccessResponse<App[]>> {
-    const res = await this.sdk.request<ApiSuccessResponse<App[]>>(
+  async list(projectId: string): Promise<{ apps: ApiSuccessResponse<App[]> }> {
+    const res = await this.sdk.request<{ apps: ApiSuccessResponse<App[]> }>(
       `/apps?projectId=${projectId}`,
       {
         method: "GET",
@@ -173,10 +174,12 @@ class WebhookAPI {
     return res;
   }
 
-  async list(appId: string): Promise<ApiSuccessResponse<Webhook[]>> {
-    const res = await this.sdk.request<ApiSuccessResponse<Webhook[]>>(
-      `/webhooks?appId=${appId}`,
-    );
+  async list(
+    appId: string,
+  ): Promise<{ webhooks: ApiSuccessResponse<Webhook[]> }> {
+    const res = await this.sdk.request<{
+      webhooks: ApiSuccessResponse<Webhook[]>;
+    }>(`/webhooks?appId=${appId}`);
     return res;
   }
 
@@ -286,6 +289,24 @@ class WebhookMessageAPI {
         data: JSON.stringify(body),
       },
     );
+    return res;
+  }
+
+  async list(): Promise<
+    ApiSuccessResponse<{
+      webhookMessages: Array<
+        WebhookMessage & { attempts: WebhookMessageAttempt[] }
+      >;
+    }>
+  > {
+    const res =
+      await this.sdk.request<
+        ApiSuccessResponse<{
+          webhookMessages: Array<
+            WebhookMessage & { attempts: WebhookMessageAttempt[] }
+          >;
+        }>
+      >(`webhook-messages`);
     return res;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,8 +83,8 @@ class AppAPI {
     return res;
   }
 
-  async list(projectId: string): Promise<{ apps: ApiSuccessResponse<App[]> }> {
-    const res = await this.sdk.request<{ apps: ApiSuccessResponse<App[]> }>(
+  async list(projectId: string): Promise<ApiSuccessResponse<{ apps: App[] }>> {
+    const res = await this.sdk.request<ApiSuccessResponse<{ apps: App[] }>>(
       `/apps?projectId=${projectId}`,
       {
         method: "GET",
@@ -176,10 +176,12 @@ class WebhookAPI {
 
   async list(
     appId: string,
-  ): Promise<{ webhooks: ApiSuccessResponse<Webhook[]> }> {
-    const res = await this.sdk.request<{
-      webhooks: ApiSuccessResponse<Webhook[]>;
-    }>(`/webhooks?appId=${appId}`);
+  ): Promise<ApiSuccessResponse<{ webhooks: Webhook[] }>> {
+    const res = await this.sdk.request<
+      ApiSuccessResponse<{
+        webhooks: Webhook[];
+      }>
+    >(`/webhooks?appId=${appId}`);
     return res;
   }
 
@@ -299,14 +301,13 @@ class WebhookMessageAPI {
       >;
     }>
   > {
-    const res =
-      await this.sdk.request<
-        ApiSuccessResponse<{
-          webhookMessages: Array<
-            WebhookMessage & { attempts: WebhookMessageAttempt[] }
-          >;
-        }>
-      >(`webhook-messages`);
+    const res = await this.sdk.request<
+      ApiSuccessResponse<{
+        webhookMessages: Array<
+          WebhookMessage & { attempts: WebhookMessageAttempt[] }
+        >;
+      }>
+    >(`/webhook-messages`);
     return res;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ import type {
   WebhookMessageTarget,
   ApiErrorResponse,
   ApiSuccessResponse,
-  WebhookMessageAttempt,
 } from "./types/index";
 import crypto from "crypto";
 import axios, { AxiosInstance } from "axios";
@@ -83,13 +82,14 @@ class AppAPI {
     return res;
   }
 
-  async list(projectId: string): Promise<ApiSuccessResponse<{ apps: App[] }>> {
-    const res = await this.sdk.request<ApiSuccessResponse<{ apps: App[] }>>(
-      `/apps?projectId=${projectId}`,
-      {
-        method: "GET",
-      },
-    );
+  async list(
+    projectId: string,
+  ): Promise<ApiSuccessResponse<App[]> & { totalCount: number }> {
+    const res = await this.sdk.request<
+      ApiSuccessResponse<App[]> & { totalCount: number }
+    >(`/apps?projectId=${projectId}`, {
+      method: "GET",
+    });
     return res;
   }
 
@@ -176,11 +176,9 @@ class WebhookAPI {
 
   async list(
     appId: string,
-  ): Promise<ApiSuccessResponse<{ webhooks: Webhook[] }>> {
+  ): Promise<ApiSuccessResponse<Webhook[]> & { totalCount: number }> {
     const res = await this.sdk.request<
-      ApiSuccessResponse<{
-        webhooks: Webhook[];
-      }>
+      ApiSuccessResponse<Webhook[]> & { totalCount: number }
     >(`/webhooks?appId=${appId}`);
     return res;
   }
@@ -295,18 +293,18 @@ class WebhookMessageAPI {
   }
 
   async list(): Promise<
-    ApiSuccessResponse<{
-      webhookMessages: Array<
-        WebhookMessage & { attempts: WebhookMessageAttempt[] }
-      >;
-    }>
+    ApiSuccessResponse<WebhookMessage[]> & {
+      totalCount: number;
+      deliveredCount: number;
+      failedCount: number;
+    }
   > {
     const res = await this.sdk.request<
-      ApiSuccessResponse<{
-        webhookMessages: Array<
-          WebhookMessage & { attempts: WebhookMessageAttempt[] }
-        >;
-      }>
+      ApiSuccessResponse<WebhookMessage[]> & {
+        totalCount: number;
+        deliveredCount: number;
+        failedCount: number;
+      }
     >(`/webhook-messages`);
     return res;
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,6 @@
 export interface Project {
   id: string;
+  appCount: number;
   name: string;
   description: string;
   createdAt: string;
@@ -43,6 +44,13 @@ export interface WebhookMessage {
   isDelivered: boolean;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface WebhookMessageAttempt {
+  _id: string;
+  response: string;
+  statusCode: number;
+  createdAt: string;
 }
 
 export type WebhookMessageTarget = { appId: string } | { webhookId: string };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,15 +25,15 @@ export interface App {
   __v: number;
 }
 
-interface WehookHeader {
+interface WebhookHeader {
   key: string;
   value: string;
   _id?: string;
 }
 export interface Webhook {
   company: string;
-  customHeaders: WehookHeader[];
-  headers: WehookHeader[];
+  customHeaders: WebhookHeader[];
+  headers: WebhookHeader[];
   id: string;
   project: string;
   url: string;
@@ -54,8 +54,8 @@ export interface Webhook {
 export interface WebhookMessageAttempt {
   _id: string;
   awsMessageId: string | null;
-  reqHeaders: WehookHeader[];
-  resHeaders: WehookHeader[];
+  reqHeaders: WebhookHeader[];
+  resHeaders: WebhookHeader[];
   id: string;
   isProcessed: boolean;
   isResend: boolean;
@@ -71,7 +71,7 @@ export interface WebhookMessage {
   id: string;
   project: string;
   environment: string;
-  headers: WehookHeader[];
+  headers: WebhookHeader[];
   status: string;
   attempts: WebhookMessageAttempt[];
   webhook: string;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,28 +1,46 @@
 export interface Project {
+  company: string;
   id: string;
-  appCount: number;
   name: string;
-  description: string;
   createdAt: string;
   updatedAt: string;
+  __v: number;
+  appCount: number;
+  webhookMessageCount: number;
+  failedWebhookMessageCount: number;
 }
 
 export interface App {
+  company: string;
+  description: string;
+  environment: {
+    _id: string;
+    name: string;
+  };
   id: string;
   name: string;
-  description: string;
-  environment: string;
+  project: string;
   createdAt: string;
   updatedAt: string;
+  __v: number;
 }
 
+interface WehookHeader {
+  key: string;
+  value: string;
+  _id?: string;
+}
 export interface Webhook {
+  company: string;
+  customHeaders: WehookHeader[];
+  headers: WehookHeader[];
   id: string;
-  name: string;
+  project: string;
   url: string;
-  customHeaders: Array<{ key: string; value: string; _id?: string }>;
-  headers: Array<{ key?: string; value?: string; _id?: string }>;
-  authMethod: {
+  createdAt: string;
+  updatedAt: string;
+  __v: number;
+  authMethod?: {
     method: WebhookAuthMethod;
     hmacHeader?: string;
     hmacSecret?: string;
@@ -31,26 +49,38 @@ export interface Webhook {
     apiKey?: string;
     apiKeyHeader?: string;
   };
-  createdAt: string;
-  updatedAt: string;
-}
-
-export interface WebhookMessage {
-  id: string;
-  webhook: string;
-  payload: string;
-  signature: string;
-  headers: Array<{ key: string; value: string; _id?: string }>;
-  isDelivered: boolean;
-  createdAt: string;
-  updatedAt: string;
 }
 
 export interface WebhookMessageAttempt {
   _id: string;
+  awsMessageId: string | null;
+  reqHeaders: WehookHeader[];
+  resHeaders: WehookHeader[];
+  id: string;
+  isProcessed: boolean;
+  isResend: boolean;
   response: string;
   statusCode: number;
+  webhookMessage: string;
   createdAt: string;
+  updatedAt: string;
+  __v: number;
+}
+export interface WebhookMessage {
+  company: string;
+  id: string;
+  project: string;
+  environment: string;
+  headers: WehookHeader[];
+  status: string;
+  attempts: WebhookMessageAttempt[];
+  webhook: string;
+  payload: string;
+  signature: string;
+  isDelivered: boolean;
+  createdAt: string;
+  updatedAt: string;
+  __v: number;
 }
 
 export type WebhookMessageTarget = { appId: string } | { webhookId: string };
@@ -89,7 +119,7 @@ export type CreateWebhookInput =
 
 export interface ApiSuccessResponse<T> {
   success: boolean;
-  message: string;
+  message?: string;
   data: T;
 }
 


### PR DESCRIPTION
This should close #4.

In addition to new structures I added a `list` method for webhookMessages.

Best.
xmok

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Webhook message listings now include attempts and delivery stats (total, delivered, failed).
  - Projects, apps and webhooks expose additional metadata (counts, company, timestamps, expanded headers and auth info).

- Refactor
  - List endpoints return unified responses with total counts for consistent paging and UI displays.

- Breaking Changes
  - List response shapes and some entity fields changed; adjust any integrations that parse list payloads or rely on previous field shapes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->